### PR TITLE
Correct Pattern Colors & Update Pattern Info

### DIFF
--- a/data/acnl_editor.js
+++ b/data/acnl_editor.js
@@ -2409,47 +2409,59 @@ function addSelectEvent(e,f){addEvent(el('select-'+e),'change',f)}
 
 
 /* Pattern structure (borrowed from Thulinma http://www.thulinma.com/acnl/)
-0x 00 - 0x 29 ( 42) = Pattern Title
-0x 2A - 0x 2B (  2) = User ID
-0x 2C - 0x 3D ( 18) = User Name
-0x 3E         (  1) = User Gender
-0x 3F         (  1) = ZeroFiller
-0x 40 - 0x 41 (  2) = Town ID
-0x 42 - 0x 55 ( 20) = Town Name
-0x 56 - 0x 57 (  2) = Unknown (values are usually random - changing seems to have no effect)
-0x 58 - 0x 66 ( 15) = Color code indexes
-0x 67		 (  1) = Unknown (value is usually random - changing seems to have no effect)
-0x 68		 (  1) = Ten? (seems to always be 0x0A)
-0x 69		 (  1) = Pattern type (normal patterns: 0x09, dresses: 0x00, photo boards: 0x08)
-0x 6A - 0x 6B (  2) = Zero? (seems to always be 0x0000)
-0x 6C - 0x26B (512) = Pattern Data 1 (mandatory)
+0x000 - 0x029 ( 42) = Pattern Title
+0x02A - 0x02B (  2) = User ID
+0x02C - 0x03D ( 18) = User Name
+0x03E         (  1) = User Gender
+0x03F         (  1) = ZeroFiller
+0x040 - 0x041 (  2) = Town ID
+0x042 - 0x055 ( 20) = Town Name
+0x056 - 0x057 (  2) = Unknown (values are usually random - changing seems to have no effect)
+0x058 - 0x066 ( 15) = Palette Indexes
+0x067		  (  1) = Unknown (value is usually random - changing seems to have no effect)
+0x068		  (  1) = Ten? (seems to always be 0x0A)
+0x069		  (  1) = Pattern Type 
+0x06A - 0x06B (  2) = Padding? (seems to always be 0x0000)
+0x06C - 0x26B (512) = Pattern Data 1 (mandatory)
 0x26C - 0x46B (512) = Pattern Data 2 (optional)
 0x46C - 0x66B (512) = Pattern Data 3 (optional)
 0x66C - 0x86B (512) = Pattern Data 4 (optional)
 0x86C - 0x86F (  4) = Zero padding (optional)
+
+Pattern Types:
+	0x00 = LongSleeveDress
+	0x01 = ShortSleeveDress
+	0x02 = SleevelessDress
+	0x03 = LongSleeveShirt
+	0x04 = ShortSleeveShirt
+	0x05 = SleevelessShirt
+	0x06 = HornedHat
+	0x07 = KnitHat
+	0x08 = PhotoBoard
+	0x09 = Pattern
 */
 const PATTERN_COLORS=[
-'ffefff','ff9aad','ef559c','ff65ad','ff0063','bd4573','ce0052','9c0031','522031',0x09,0x0a,0x0b,0x0c,0x0d,0x0e,'ffffff',
-'ffbace','ff7573','de3010','ff5542','ff0000','ce6563','bd4542','bd0000','8c2021',0x19,0x1a,0x1b,0x1c,0x1d,0x1e,'ececec',
-'decfbd','ffcf63','de6521','ffaa21','ff6500','bd8a52','de4500','bd4500','633010',0x29,0x2a,0x2b,0x2c,0x2d,0x2e,'dadada',
-'ffefde','ffdfce','ffcfad','ffba8c','ffaa8c','de8a63','bd6542','9c5531','8c4521',0x39,0x3a,0x3b,0x3c,0x3d,0x3e,'c8c8c8',
-'ffcfff','ef8aff','ce65de','bd8ace','ce00ff','9c659c','8c00ad','520073','310042',0x49,0x4a,0x4b,0x4c,0x4d,0x4e,'b6b6b6',
-'ffbaff','ff9aff','de20bd','ff55ef','ff00ce','8c5573','bd009c','8c0063','520042',0x59,0x5a,0x5b,0x5c,0x5d,0x5e,'a3a3a3',
-'deba9c','ceaa73','734531','ad7542','9c3000','733021','522000','311000','211000',0x69,0x6a,0x6b,0x6c,0x6d,0x6e,'919191',
-'ffffce','ffff73','dedf21','ffff00','ffdf00','ceaa00','9c9a00','8c7500','525500',0x79,0x7a,0x7b,0x7c,0x7d,0x7e,'7f7f7f',
-'debaff','bd9aef','6330ce','9c55ff','6300ff','52458c','42009c','210063','211031',0x89,0x8a,0x8b,0x8c,0x8d,0x8e,'6d6d6d',
-'bdbaff','8c9aff','3130ad','3155ef','0000ff','31308c','0000ad','101063','000021',0x99,0x9a,0x9b,0x9c,0x9d,0x9e,'5b5b5b',
-'9cefbd','63cf73','216510','42aa31','008a31','527552','215500','103021','002010',0xa9,0xaa,0xab,0xac,0xad,0xae,'484848',
-'deffbd','ceff8c','8caa52','addf8c','8cff00','adba9c','63ba00','529a00','316500',0xb9,0xba,0xbb,0xbc,0xbd,0xbe,'363636',
-'bddfff','73cfff','31559c','639aff','1075ff','4275ad','214573','002073','001042',0xc9,0xca,0xcb,0xcc,0xcd,0xce,'242424',
-'adffff','52ffff','008abd','52bace','00cfff','429aad','00658c','004552','002031',0xd9,0xda,0xdb,0xdc,0xdd,0xde,'121212',
-'ceffef','adefde','31cfad','52efbd','00ffce','73aaad','00aa9c','008a73','004531',0xe9,0xea,0xeb,0xec,0xed,0xee,'000000',
-'adffad','73ff73','63df42','00ff00','21df21','52ba52','00ba00','008a00','214521',0xf9,0xfa,0xfb,0xfc,0xfd,0xfe,0xff
+'ffeeff','ff99aa','ee5599','ff66aa','ff0066','bb4477','cc0055','990033','552233','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff',
+'ffbbcc','ff7777','dd3311','ff5544','ff0000','cc6666','bb4444','bb0000','882222','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff','eeeeee',
+'ddccbb','ffcc66','dd6622','ffaa22','ff6600','bb8855','dd4400','bb4400','663311','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff','dddddd',
+'ffeedd','ffddcc','ffccaa','ffbb88','ffaa88','dd8866','bb6644','995533','884422','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff','cccccc',
+'ffccff','ee88ff','cc66dd','bb88cc','cc00ff','996699','8800aa','550077','330044','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff','bbbbbb',
+'ffbbff','ff99ff','dd22bb','ff55ee','ff00cc','885577','bb0099','880066','550044','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff','aaaaaa',
+'ddbb99','ccaa77','774433','aa7744','993300','773322','552200','331100','221100','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff','999999',
+'ffffcc','ffff77','dddd22','ffff00','ffdd00','ccaa00','999900','887700','555500','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff','888888',
+'ddbbff','bb99ee','6633cc','9955ff','6600ff','554488','440099','220066','221133','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff','777777',
+'bbbbff','8899ff','3333aa','3355ee','0000ff','333388','0000aa','111166','000022','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff','666666',
+'99eebb','66cc77','226611','44aa33','008833','557755','225500','113322','002211','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff','555555',
+'ddffbb','ccff88','88aa55','aadd88','88ff00','aabb99','66bb00','559900','336600','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff','444444',
+'bbddff','77ccff','335599','6699ff','1177ff','4477aa','224477','002277','001144','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff','333333',
+'aaffff','55ffff','0088bb','55bbcc','00ccff','4499aa','006688','004455','002233','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff','222222',
+'ccffee','aaeedd','33ccaa','55eebb','00ffcc','77aaaa','00aa99','008877','004433','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff','000000',
+'aaffaa','77ff77','66dd44','00ff00','22dd22','55bb55','00bb00','008800','224422','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff','ffffff'
 /*
 NOTES:
-	* last columns are greys
-	* 0x?9 - 0x?e aren't used. Not sure what they do in-game. can somebody test this?
-	* 0xff is displayed as white in-game, editing it causes a game freeze
+	* The last columns are greys.
+	* 0xX9 - 0xXE aren't used. They're all white (0x00FFFFFF).
+	* 0xFF is 0xFFFFFFFF. It crashes in New Leaf, but not the Welcome Amiibo update.
 */
 ];
 function Pattern(offset, n){


### PR DESCRIPTION
The pattern colors are stored as RGBA4 colors in the games files, and were converted to RGBA8 to get the correct colors. Also included the various pattern types in the pattern info comment.